### PR TITLE
  1. The z-symmetry breaking feature that:

### DIFF
--- a/bash_training_scripts/train_d2r2_WF_zsymbreak.sh
+++ b/bash_training_scripts/train_d2r2_WF_zsymbreak.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Train Comformer on D2R2 WF properties with z-symmetry breaking
+
+# Ensure we're in the project root directory
+cd "$(dirname "$0")/.." || exit 1
+
+# Create output directory
+mkdir -p output/D2R2_WF_zsymbreak
+
+# Run the training script
+python -m comformer.scripts.train_D2R2_WF_zsymbreak

--- a/comformer/config.py
+++ b/comformer/config.py
@@ -1,3 +1,5 @@
+
+
 """Pydantic model for default configuration and validation."""
 """Implementation based on the template of Matformer."""
 
@@ -184,6 +186,7 @@ class TrainingConfig(BaseSettings):
     pyg_input: bool = False
     use_lattice: bool = False
     use_angle: bool = False
+    break_z_symmetry: bool = False
 
     # model configuration
     model: Union[

--- a/comformer/graphs.py
+++ b/comformer/graphs.py
@@ -436,7 +436,15 @@ class PygGraph(object):
         )
         atom_lat = atom_lat.repeat(node_features.shape[0],1,1)
         edge_index = torch.cat((u.unsqueeze(0), v.unsqueeze(0)), dim=0).long()
-        g = Data(x=node_features, edge_index=edge_index, edge_attr=r, edge_type=l, edge_nei=nei, atom_lat=atom_lat)
+        
+        # Extract z-coordinates for z-symmetry breaking
+        z_coords = None
+        if atoms is not None:
+            # Get cartesian coordinates and extract z component
+            cart_coords = atoms.cart_coords
+            z_coords = torch.tensor(cart_coords[:, 2], dtype=torch.get_default_dtype()).unsqueeze(1)
+        
+        g = Data(x=node_features, edge_index=edge_index, edge_attr=r, edge_type=l, edge_nei=nei, atom_lat=atom_lat, z_coords=z_coords)
         
         return g
 

--- a/comformer/models/comformer.py
+++ b/comformer/models/comformer.py
@@ -35,6 +35,7 @@ class iComformerConfig(BaseSettings):
     use_angle: bool = False
     angle_lattice: bool = False
     classification: bool = False
+    break_z_symmetry: bool = False
 
     class Config:
         """Configure model settings behavior."""
@@ -63,6 +64,7 @@ class eComformerConfig(BaseSettings):
     use_angle: bool = False
     angle_lattice: bool = False
     classification: bool = False
+    break_z_symmetry: bool = False
 
     class Config:
         """Configure model settings behavior."""
@@ -88,6 +90,8 @@ class eComformer(nn.Module): # eComFormer
         super().__init__()
         self.classification = config.classification
         self.use_angle = config.use_angle
+        self.break_z_symmetry = config.break_z_symmetry
+        
         self.atom_embedding = nn.Linear(
             config.atom_input_features, config.node_features
         )
@@ -110,9 +114,27 @@ class eComformer(nn.Module): # eComFormer
 
         self.equi_update = ComformerConvEqui(in_channels=config.node_features, out_channels=config.node_features, edge_dim=config.node_features, use_second_order_repr=True)
 
-        self.fc = nn.Sequential(
-            nn.Linear(config.node_features, config.fc_features), nn.SiLU()
-        )
+        # Add z-coordinate processing if break_z_symmetry is enabled
+        if self.break_z_symmetry:
+            # Small network to process z-coordinates
+            self.z_embedding = nn.Sequential(
+                nn.Linear(1, 16),
+                nn.SiLU(),
+                nn.Linear(16, 32),
+                nn.SiLU(),
+            )
+            # Updated FC layer to process combined features
+            self.fc = nn.Sequential(
+                nn.Linear(config.node_features + 32, config.fc_features), 
+                nn.SiLU()
+            )
+        else:
+            # Original FC layer
+            self.fc = nn.Sequential(
+                nn.Linear(config.node_features, config.fc_features), 
+                nn.SiLU()
+            )
+            
         self.sigmoid = nn.Sigmoid()
 
         if self.classification:
@@ -144,9 +166,20 @@ class eComformer(nn.Module): # eComFormer
         # crystal-level readout
         features = scatter(node_features, data.batch, dim=0, reduce="mean")
         
+        # Process z-coordinates if break_z_symmetry is enabled
+        if self.break_z_symmetry and hasattr(data, 'z_coords'):
+            # Process z-coordinates
+            z_features = self.z_embedding(data.z_coords)
+            
+            # Aggregate z-features at the crystal level (same as node_features)
+            z_crystal_features = scatter(z_features, data.batch, dim=0, reduce="mean")
+            
+            # Combine node features with z-features
+            combined_features = torch.cat([features, z_crystal_features], dim=1)
+            features = self.fc(combined_features)
+        else:
+            features = self.fc(features)
         
-        features = self.fc(features)
-
         out = self.fc_out(features)
         if self.link:
             out = self.link(out)
@@ -164,6 +197,8 @@ class iComformer(nn.Module): # iComFormer
         super().__init__()
         self.classification = config.classification
         self.use_angle = config.use_angle
+        self.break_z_symmetry = config.break_z_symmetry
+        
         self.atom_embedding = nn.Linear(
             config.atom_input_features, config.node_features
         )
@@ -196,9 +231,27 @@ class iComformer(nn.Module): # iComFormer
 
         self.edge_update_layer = ComformerConv_edge(in_channels=config.node_features, out_channels=config.node_features, heads=config.node_layer_head, edge_dim=config.node_features)
 
-        self.fc = nn.Sequential(
-            nn.Linear(config.node_features, config.fc_features), nn.SiLU()
-        )
+        # Add z-coordinate processing if break_z_symmetry is enabled
+        if self.break_z_symmetry:
+            # Small network to process z-coordinates
+            self.z_embedding = nn.Sequential(
+                nn.Linear(1, 16),
+                nn.SiLU(),
+                nn.Linear(16, 32),
+                nn.SiLU(),
+            )
+            # Updated FC layer to process combined features
+            self.fc = nn.Sequential(
+                nn.Linear(config.node_features + 32, config.fc_features), 
+                nn.SiLU()
+            )
+        else:
+            # Original FC layer
+            self.fc = nn.Sequential(
+                nn.Linear(config.node_features, config.fc_features), 
+                nn.SiLU()
+            )
+            
         self.sigmoid = nn.Sigmoid()
 
         if self.classification:
@@ -234,7 +287,19 @@ class iComformer(nn.Module): # iComFormer
         # crystal-level readout
         features = scatter(node_features, data.batch, dim=0, reduce="mean")
         
-        features = self.fc(features)
+        # Process z-coordinates if break_z_symmetry is enabled
+        if self.break_z_symmetry and hasattr(data, 'z_coords'):
+            # Process z-coordinates
+            z_features = self.z_embedding(data.z_coords)
+            
+            # Aggregate z-features at the crystal level (same as node_features)
+            z_crystal_features = scatter(z_features, data.batch, dim=0, reduce="mean")
+            
+            # Combine node features with z-features
+            combined_features = torch.cat([features, z_crystal_features], dim=1)
+            features = self.fc(combined_features)
+        else:
+            features = self.fc(features)
 
         out = self.fc_out(features)
         if self.link:

--- a/comformer/scripts/train_D2R2_WF_zsymbreak.py
+++ b/comformer/scripts/train_D2R2_WF_zsymbreak.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import logging
+import structlog
+
+# Set up structured logging
+logger = structlog.get_logger()
+logger.info("Starting D2R2 WF properties training with z-symmetry breaking")
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+comformer_dir = os.path.abspath(os.path.join(current_dir, "../.."))
+sys.path.append(comformer_dir)
+
+from comformer.train_props import train_prop_model 
+
+# Create output directory first - simple fix to avoid directory not found error
+output_dir = "output/D2R2_WF_zsymbreak"
+os.makedirs(output_dir, exist_ok=True)
+
+train_prop_model(
+    dataset="D2R2_surface_data",
+    prop="WF",           # Use the WF field that combines WF_bottom and WF_top
+    name="eComformer",   # Use equivariant model
+    pyg_input=True,
+    n_epochs=350,
+    max_neighbors=25,
+    cutoff=4.0,
+    batch_size=64,
+    use_lattice=True,    # Required for proper graph construction
+    use_angle=True,
+    break_z_symmetry=True,  # Enable z-symmetry breaking
+    save_dataloader=True,
+    output_dir=output_dir,
+    output_features=2,   # Critical: final output dimension set to 2 for WF_bottom and WF_top
+    data_path="data/DFT_data.csv"  # Add explicit data path
+)

--- a/comformer/train_props.py
+++ b/comformer/train_props.py
@@ -40,6 +40,7 @@ def train_prop_model(
     pyg_input=False,
     use_lattice=False,
     use_angle=False,
+    break_z_symmetry=False,
     output_dir=None,
     neighbor_strategy="k-nearest",
     test_only=False,
@@ -105,7 +106,9 @@ def train_prop_model(
     config["pyg_input"] = pyg_input
     config["use_lattice"] = use_lattice
     config["use_angle"] = use_angle
+    config["break_z_symmetry"] = break_z_symmetry
     config["model"]["use_angle"] = use_angle
+    config["model"]["break_z_symmetry"] = break_z_symmetry
     config["neighbor_strategy"] = neighbor_strategy
     # config["output_dir"] = '.'
     if output_dir is not None:


### PR DESCRIPTION
    - Preserves equivariance/invariance in the x-y plane
    - Breaks symmetry in the z-direction for better surface property modeling
    - Works with both iComformer and eComformer models
    - Is controlled by a simple configuration flag
  2. Key implementation files:
    - Added break_z_symmetry flag to config.py
    - Modified graphs.py to extract and store z-coordinates
    - Updated both model implementations in comformer.py
    - Created a training script that enables the feature

  This implementation should help improve the model's performance on surface properties like Work Function (WF) by providing explicit information about z-directionality while maintaining the important equivariance properties in the x-y plane.